### PR TITLE
Changed PGUA name to Andersen AFB

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5297,7 +5297,7 @@ theaters:
         recoveries:
           none: none
       pgua:
-        name: Andersen Air Force Base
+        name: Andersen AFB
         ground: 275.8
         atis: 254.325
         tower: 233.7


### PR DESCRIPTION
Changed PGUA name to ANdersen AFB to shorten Name for Kneeboard rendering